### PR TITLE
Add Owners list feature

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -89,13 +89,13 @@ class OwnerController {
 		return "owners/findOwners";
 	}
 
-	@GetMapping("/owners")
-	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
-			Model model) {
-		// allow parameterless GET request for /owners to return all records
-		if (owner.getLastName() == null) {
-			owner.setLastName(""); // empty string signifies broadest possible search
-		}
+        @GetMapping("/owners")
+        public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
+                        Model model) {
+                // allow parameterless GET request for /owners to return all records
+                if (owner.getLastName() == null) {
+                        owner.setLastName(""); // empty string signifies broadest possible search
+                }
 
 		// find owners by last name
 		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, owner.getLastName());
@@ -111,9 +111,17 @@ class OwnerController {
 			return "redirect:/owners/" + owner.getId();
 		}
 
-		// multiple owners found
-		return addPaginationModel(page, model, ownersResults);
-	}
+                // multiple owners found
+                return addPaginationModel(page, model, ownersResults);
+        }
+
+       @GetMapping("/owners/list")
+       public String listOwners(@RequestParam(defaultValue = "1") int page, Model model) {
+               int pageSize = 5;
+               Pageable pageable = PageRequest.of(page - 1, pageSize);
+               Page<Owner> ownersResults = this.owners.findAll(pageable);
+               return addPaginationModel(page, model, ownersResults);
+       }
 
 	private String addPaginationModel(int page, Model model, Page<Owner> paginated) {
 		List<Owner> listOwners = paginated.getContent();

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -16,6 +16,7 @@ owners=Owners
 addOwner=Add Owner
 findOwner=Find Owner
 findOwners=Find Owners
+listOwners=List Owners
 updateOwner=Update Owner
 vets=Veterinarians
 name=Name

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -47,6 +47,10 @@
             <span class="fa fa-search" aria-hidden="true"></span>
             <span th:text="#{findOwners}">Find owners</span>
           </li>
+          <li th:replace="~{::menuItem ('/owners/list','owners','list owners','th-list',#{listOwners})}">
+            <span class="fa fa-th-list" aria-hidden="true"></span>
+            <span th:text="#{listOwners}">List Owners</span>
+          </li>
 
           <li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list',#{vets})}">
             <span class="fa fa-th-list" aria-hidden="true"></span>

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -139,12 +139,21 @@ class OwnerControllerTests {
 			.andExpect(view().name("owners/findOwners"));
 	}
 
-	@Test
-	void testProcessFindFormSuccess() throws Exception {
-		Page<Owner> tasks = new PageImpl<>(List.of(george(), new Owner()));
-		when(this.owners.findByLastNameStartingWith(anyString(), any(Pageable.class))).thenReturn(tasks);
-		mockMvc.perform(get("/owners?page=1")).andExpect(status().isOk()).andExpect(view().name("owners/ownersList"));
-	}
+        @Test
+        void testProcessFindFormSuccess() throws Exception {
+                Page<Owner> tasks = new PageImpl<>(List.of(george(), new Owner()));
+                when(this.owners.findByLastNameStartingWith(anyString(), any(Pageable.class))).thenReturn(tasks);
+                mockMvc.perform(get("/owners?page=1")).andExpect(status().isOk()).andExpect(view().name("owners/ownersList"));
+        }
+
+       @Test
+       void testListOwners() throws Exception {
+               Page<Owner> tasks = new PageImpl<>(List.of(george(), new Owner()));
+               when(this.owners.findAll(any(Pageable.class))).thenReturn(tasks);
+               mockMvc.perform(get("/owners/list?page=1"))
+                               .andExpect(status().isOk())
+                               .andExpect(view().name("owners/ownersList"));
+       }
 
 	@Test
 	void testProcessFindFormByLastName() throws Exception {


### PR DESCRIPTION
## Summary
- implement `/owners/list` endpoint to display all owners with pagination
- display "List Owners" link in navigation
- add `listOwners` message key
- test new controller endpoint

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6847fade620c8327a574efe00af27e25